### PR TITLE
Adjustments for requests >= 1.0 API, Depend on requests >= 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def get_version():
         return VERSION
     raise RuntimeError('No version info found.')
 
-requirements = ['requests == 0.14.0', 'clint == 0.3.1']
+requirements = ['requests >= 2.0.0', 'clint == 0.3.1']
 if sys.version_info < (2, 7):
     requirements.append('argparse')
 elif sys.version_info < (2, 6):


### PR DESCRIPTION
Before 1.0, `response.json` was a property (None if decode failed)
https://requests.readthedocs.io/en/v0.14.0/user/quickstart/#json-response-content
In 1.0 it became `response.json()` method (raises if decode failed)
https://requests.readthedocs.io/en/master/user/quickstart/#json-response-content

No idea if there were other API changes that affect this project.

I upgraded the dependency in setup.py to an open-ended >= 2, < 3, I think we can trust requests to obey semver.
(Can pin down a specific version if you prefer.  It's just that my motivation was coming from debugging the gists Fedora package, and as most linux distros fedora carries a single requests version for all apps — so either the gists package will block python2-requests package from upgrading, or much more likely they'll ignore the version you specify here and depend on a similary wide range...)

Are there any tests to run?
I've successfully run a few commands :
```
gists list -u cben
gists show c858283bd4fcbaeec97ea0a5e5f046f9
gists get c858283bd4fcbaeec97ea0a5e5f046f9 -f
1.tagging_setup.rb
```

`gists authorize` succesfully failed ;-) for me, as I have 2FA enabled.